### PR TITLE
BUG FIX: State not updating in edit user profile

### DIFF
--- a/js/countries-main.js
+++ b/js/countries-main.js
@@ -1,7 +1,5 @@
 jQuery(document).ready(function($){
 
-	console.log(pmpro_state_dropdowns);
-
 	//for compatibility with older PMPro, make sure bcountry fields have ids
 	jQuery("[name='bcountry']").attr('id', 'bcountry');
 	jQuery("[name='scountry']").attr('id', 'scountry');	

--- a/js/countries-main.js
+++ b/js/countries-main.js
@@ -14,7 +14,7 @@ jQuery(document).ready(function($){
 		jQuery('#bcountry').attr('class', 'crs-country').attr('data-region-id', 'bstate').attr('data-default-value', pmpro_state_dropdowns.bcountry);	
 		jQuery('#bcountry').attr('data-value', 'shortcode');
 		
-		jQuery("#bstate").replaceWith('<select id="bstate" name="bstate"></select>');  //convert to dropdown so states can auto-populate
+		jQuery("#bstate").replaceWith('<select id="bstate" name="'+pmpro_state_dropdowns.state_id+'"></select>');  //convert to dropdown so states can auto-populate
 		jQuery('#bstate').attr('data-default-value', pmpro_state_dropdowns.bstate );
 		jQuery('#bstate').attr('data-value', 'shortcode');
 

--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -74,6 +74,13 @@ class PMPro_State_Dropdowns {
 		if( is_admin() && isset($_REQUEST['page']) && $_REQUEST['page'] == 'pmpro-orders' && !empty($_GET['order']) ){
 			$morder = new MemberOrder($_GET['order']);
 		}
+
+		//if the page is edit user or profile, change the ID to '#pmpro_bstate' otherwise default to '#bstate'.
+		if( $script_name == 'user-edit.php' || $script_name == 'profile.php' ){
+			$user_saved_countries['state_id'] = 'pmpro_bstate';
+		}else{
+			$user_saved_countries['state_id'] = 'bstate';
+		}
 		
 		//if $morder is not empty (i.e. on the orders page try to get details from REQUEST or USER META )
 		if( empty($morder) ){


### PR DESCRIPTION
BUG FIX: When updating a user’s profile, state field would not save or
update values.

This was caused by JS replacing the state fields as a dropdown and the
ID value (by PMPro default) was different to each other.

Checkout page ID for state was ‘#bstate’ whereas loading the state
fields in the edit user profile was ‘#pmpro_bstate’.