### PR TITLE
Add dev filters to decide where to move the country fields (or not move)

### DIFF
--- a/js/countries-main.js
+++ b/js/countries-main.js
@@ -17,8 +17,11 @@ jQuery(document).ready(function($){
 		jQuery('#bstate').attr('data-value', 'shortcode');
 
 		//move #bcountry field and label above #bfirstname field and label
-		var bcountryDiv = jQuery('label[for="bcountry"]').closest('div');
-		bcountryDiv.insertBefore(jQuery('label[for="bfirstname"]').closest('div'));
+		if (pmpro_state_dropdowns.bcountry_before_field) {
+			var bcountryDiv = jQuery('label[for="bcountry"]').closest('div');
+			bcountryDiv.insertBefore(jQuery('label[for="' + pmpro_state_dropdowns.bcountry_before_field + '"]').closest('div'));
+		}
+
 		window.crs.init()
 	}	
 
@@ -35,8 +38,11 @@ jQuery(document).ready(function($){
 		jQuery("#sstate").attr('data-value', 'shortcode');
 
 		//move #scountry field and label above #sfirstname field and label
-		var scountryDiv = jQuery('label[for="scountry"]').closest('div');
-		scountryDiv.insertBefore(jQuery('label[for="sfirstname"]').closest('div'));
+		if (pmpro_state_dropdowns.scountry_before_field) {
+			var scountryDiv = jQuery('label[for="scountry"]').closest('div');
+			scountryDiv.insertBefore(jQuery('label[for="' + pmpro_state_dropdowns.scountry_before_field + '"]').closest('div'));
+		}
+
 		window.crs.init()
 	}
 

--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -118,6 +118,9 @@ class PMPro_State_Dropdowns {
 			$user_saved_countries['bstate'] = $morder->billing->state;			
 		}	
 
+		$user_saved_countries['bcountry_before_field'] = apply_filters( 'pmpro_state_dropdowns_bcountry_before_field', 'bfirstname' );
+		$user_saved_countries['scountry_before_field'] = apply_filters( 'pmpro_state_dropdowns_scountry_before_field', 'sfirstname' );
+
 		wp_localize_script( 'pmpro-countries-main', 'pmpro_state_dropdowns', $user_saved_countries );
 		
 		/**


### PR DESCRIPTION
The state dropdown add-on is moving the country (billing and shipping) field just before the bfirstname/sfirstname.

Not always the desired behaviour. Sometimes you just don't want to move the field, or move it somewhere else.
That's where these 2 new filters comes in handy.

Filters:
```
pmpro_state_dropdowns_bcountry_before_field
pmpro_state_dropdowns_scountry_before_field
```

Usage:

## Don't move the bcountry field

```
add_filter( 'pmpro_state_dropdowns_bcountry_before_field', '__return_false' );
```
## Move the bcountry field just before the bstate field.

```
add_filter( 'pmpro_state_dropdowns_bcountry_before_field', function( $fieldname ){
	return 'bstate';
} );
```
