### PR TITLE
Fatal error when PMPro core is inactive

### DIFF
--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -50,7 +50,7 @@ class PMPro_State_Dropdowns {
 	public static function enqueue_styles_scripts(){
 		global $current_user, $user_id, $order_id, $pmpro_default_country, $pmpro_pages;
 
-		if( ! function_exists( 'pmpro_is_checkout' ) ) {
+		if ( ! function_exists( 'pmpro_is_checkout' ) ) {
 			return;
 		}
 

--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -50,6 +50,10 @@ class PMPro_State_Dropdowns {
 	public static function enqueue_styles_scripts(){
 		global $current_user, $user_id, $order_id, $pmpro_default_country, $pmpro_pages;
 
+		if( ! function_exists( 'pmpro_is_checkout' ) ) {
+			return;
+		}
+
 		//fallback to current user on pages that don't support $user_id variable.
 		if( empty( $user_id ) ){
 			$user_id = $current_user->ID;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We check for the pmpro_is_checkout now before it gets used as this can throw a fatal error

### How to test the changes in this Pull Request:

1. Have PMPro + State Dropdowns active
2. Deactivate PMPro
3. Try edit a page or similar so that the admin styles are enqueued - no fatal error should be thrown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

