### PR TITLE
Support V3.1 and Shipping improvements

### DIFF
--- a/js/countries-main.js
+++ b/js/countries-main.js
@@ -9,7 +9,7 @@ jQuery(document).ready(function ($) {
 
 	// Populate the dropdown on page load.
 	var selected_states = pmprosd_states[pmpro_state_dropdowns.bcountry];
-	pmprosd_populate_dropdown("[name='bstate']", selected_states, pmpro_state_labels.region, '');
+	pmprosd_populate_dropdown("#bstate", selected_states, pmpro_state_labels.region, '');
 
 	//make sure we have a bcountry field to work with
 	if (jQuery('#bcountry').length) {
@@ -22,37 +22,37 @@ jQuery(document).ready(function ($) {
 		var states_for_countries = pmprosd_states[pmpro_state_dropdowns.bcountry];
 		if (typeof states_for_countries !== 'undefined' && jQuery(states_for_countries).length > 0) {
 			if (jQuery('#bstate').hasClass('pmpro_error')) {
-				jQuery("#bstate").replaceWith('<select id="bstate" name="bstate" class="pmpro_error"></select>');  //convert to dropdown so states can auto-populate
+				jQuery("#bstate").replaceWith('<select id="bstate" name="bstate" class="pmpro_error pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate
 			} else {
-				jQuery("#bstate").replaceWith('<select id="bstate" name="bstate"></select>');  //convert to dropdown so states can auto-populate
+				jQuery("#bstate").replaceWith('<select id="bstate" name="bstate" class="pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate
 			}
 
-			pmprosd_populate_dropdown("[name='bstate']", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.bstate);
+			pmprosd_populate_dropdown("#bstate", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.bstate);
 		} else {
 			var selected_state = (typeof pmpro_state_dropdowns.bstate !== 'undefined') ? pmpro_state_dropdowns.bstate : "";
 			if (jQuery('#bstate').hasClass('pmpro_error')) {
-				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" class="pmpro_error" value="' + selected_state + '"/>');
+				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" class="pmpro_error pmpro_form_input pmpro_form_input-text" value="' + selected_state + '"/>');
 			} else {
-				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" value="' + selected_state + '"/>');
+				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '"/>');
 			}
 		}
 
 	}
 
-	jQuery('body').on('change', "[name='bcountry']", function () {
+	jQuery('body').on('change', "#bcountry", function () {
 		var selected_country = jQuery(this).val();
 		var selected_states = pmprosd_states[selected_country];
 		if (typeof selected_states !== 'undefined' && jQuery(selected_states).length > 0) {
-			if (jQuery("[name='bstate']").hasClass('pmpro_error')) {
-				jQuery("[name='bstate']").replaceWith('<select id="bstate" name="bstate" class="pmpro_error"></select>');  //convert to dropdown so states can auto-populate
+			if (jQuery("#bstate").hasClass('pmpro_error')) {
+				jQuery("#bstate").replaceWith('<select id="bstate" name="bstate" class="pmpro_error pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate
 			} else {
-				jQuery("[name='bstate']").replaceWith('<select id="bstate" name="bstate"></select>');  //convert to dropdown so states can auto-populate
+				jQuery("#bstate").replaceWith('<select id="bstate" name="bstate" class="pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate
 			}
-			pmprosd_populate_dropdown("[name='bstate']", selected_states, pmpro_state_labels.region, '');
+			pmprosd_populate_dropdown("#bstate", selected_states, pmpro_state_labels.region, '');
 		} else {
 			var selected_state = (typeof pmpro_state_dropdowns.bstate !== 'undefined') ? pmpro_state_dropdowns.bstate : "";
 			if (jQuery('#bstate').hasClass('pmpro_error')) {
-				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" class="pmpro_error" value="' + selected_state + '"/>');
+				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" class="pmpro_error pmpro_form_input pmpro_form_input-text" value="' + selected_state + '"/>');
 			} else {
 				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" value="' + selected_state + '"/>');
 			}
@@ -60,52 +60,60 @@ jQuery(document).ready(function ($) {
 	});
 
 	//pmpro-shipping support
-	if (jQuery('#scountry').length) {
+	if (jQuery('#pmpro_scountry').length) {
 
-		pmprosd_populate_dropdown("#scountry", pmprosd_countries, pmpro_state_labels.country, pmpro_state_dropdowns.scountry);
+		// Move Shipping Country field above state for better UX.
+		jQuery('#pmpro_scountry_div').insertBefore(jQuery('#pmpro_sstate_div').closest('div'));
 
-		//move #scountry field and label above #sfirstname field and label
-		var scountryDiv = jQuery('label[for="scountry"]').closest('div');
-		scountryDiv.insertBefore(jQuery('label[for="sfirstname"]').closest('div'));
+		pmprosd_populate_dropdown("#pmpro_scountry", pmprosd_countries, pmpro_state_labels.country, pmpro_state_dropdowns.scountry);
 
 		var selected_states = pmprosd_states[pmpro_state_dropdowns.scountry];
 		if (typeof selected_states !== 'undefined' && jQuery(selected_states).length > 0) {
-			if (jQuery("#sstate").hasClass('pmpro_error')) {
-				jQuery('#sstate').replaceWith('<select id="sstate" name="sstate" class="pmpro_error"></select>');  //convert to dropdown so states can auto-populate   
+			if (jQuery("#pmpro_sstate").hasClass('pmpro_error')) {
+				jQuery('#pmpro_sstate').replaceWith('<select id="pmpro_sstate" name="pmpro_sstate" class="pmpro_error pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate   
 			} else {
-				jQuery('#sstate').replaceWith('<select id="sstate" name="sstate" ></select>');  //convert to dropdown so states can auto-populate   
+				jQuery('#pmpro_sstate').replaceWith('<select id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate   
 			}
-			pmprosd_populate_dropdown("#sstate", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.sstate);
+			pmprosd_populate_dropdown("#pmpro_sstate", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.sstate);
 		} else {
 			var selected_state = (typeof pmpro_state_dropdowns.sstate !== 'undefined') ? pmpro_state_dropdowns.sstate : "";
-			if (jQuery("#sstate").hasClass('pmpro_error')) {
-				jQuery("#sstate").replaceWith('<input type="text" id="sstate" name="sstate" class="pmpro_error" value="' + selected_state + '" />');
+			if (jQuery("#pmpro_sstate").hasClass('pmpro_error')) {
+				jQuery("#pmpro_sstate").replaceWith('<input type="text" id="pmpro_sstate" name="pmpro_sstate" class="pmpro_error pmpro_form_input pmpro_form_input-text" value="' + selected_state + '" />');
 			} else {
-				jQuery("#sstate").replaceWith('<input type="text" id="sstate" name="sstate" value="' + selected_state + '" />');
+				jQuery("#pmpro_sstate").replaceWith('<input type="text" id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '" />');
 			}
 		}
 
 	}
 
-	jQuery('body').on('change', "[name='scountry']", function () {
+	jQuery('body').on('change', "#pmpro_scountry", function () {
 		var selected_country = jQuery(this).val();
 		var selected_states = pmprosd_states[selected_country];
 		if (typeof selected_states !== 'undefined' && jQuery(selected_states).length > 0) {
-			if (jQuery("[name='sstate']").hasClass('pmpro_error')) {
-				jQuery("[name='sstate']").replaceWith('<select id="sstate" name="sstate" class="pmpro_error"></select>');  //convert to dropdown so states can auto-populate   
+			if (jQuery("#pmpro_sstate").hasClass('pmpro_error')) {
+				jQuery("#pmpro_sstate").replaceWith('<select id="pmpro_sstate" name="pmpro_sstate" class="pmpro_error pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate   
 			} else {
-				jQuery("[name='sstate']").replaceWith('<select id="sstate" name="sstate"></select>');  //convert to dropdown so states can auto-populate   
+				jQuery("#pmpro_sstate").replaceWith('<select id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate   
 			}
-			pmprosd_populate_dropdown("[name='sstate']", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.sstate);
+			pmprosd_populate_dropdown("#pmpro_sstate", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.sstate);
 		} else {
 			var selected_state = (typeof pmpro_state_dropdowns.sstate !== 'undefined') ? pmpro_state_dropdowns.sstate : "";
-			if (jQuery("#sstate").hasClass('pmpro_error')) {
-				jQuery("#sstate").replaceWith('<input type="text" id="sstate" name="sstate" class="pmpro_error" value="' + selected_state + '" />');
+			if (jQuery("#pmpro_sstate").hasClass('pmpro_error')) {
+				jQuery("#pmpro_sstate").replaceWith('<input type="text" id="pmpro_sstate" name="pmpro_sstate" class="pmpro_error" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '" />');
 			} else {
-				jQuery("#sstate").replaceWith('<input type="text" id="sstate" name="sstate" value="' + selected_state + '" />');
+				jQuery("#pmpro_sstate").replaceWith('<input type="text" id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '" />');
 			}
 		}
 	});
+
+	// Add support for Same as billing and set the state to a text field.
+	jQuery('#pmproship_same_billing_address').on('change', function () {
+		if (jQuery(this).is(':checked')) {
+			var selected_state = jQuery('#bstate').val();
+			jQuery("#pmpro_sstate").replaceWith('<input type="text" id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '" />');
+		}
+	});
+
 
 	//PMPro orders page support
 	if (jQuery('#billing_country').length) {
@@ -116,9 +124,9 @@ jQuery(document).ready(function ($) {
 		var selected_states = pmprosd_states[pmpro_state_dropdowns.bcountry];
 
 		if (typeof selected_states !== 'undefined' && jQuery(selected_states).length > 0) {
-			jQuery('#billing_state').replaceWith('<select id="billing_state" name="billing_state"></select>');
+			jQuery('#billing_state').replaceWith('<select id="billing_state" name="billing_state" class="pmpro_form_input pmpro_form_input-select"></select>');
 		} else {
-			jQuery('#billing_state').replaceWith('<input type="text" id="billing_state" name="billing_state" />');
+			jQuery('#billing_state').replaceWith('<input type="text" id="billing_state" name="billing_state" class="pmpro_form_input pmpro_form_input-text" />');
 		}
 
 		pmprosd_populate_dropdown("#billing_state", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.bstate);
@@ -131,9 +139,9 @@ jQuery(document).ready(function ($) {
 		var selected_states = pmprosd_states[selected_country];
 
 		if (typeof selected_states !== 'undefined' && jQuery(selected_states).length > 0) {
-			jQuery('#billing_state').replaceWith('<select id="billing_state" name="billing_state"></select>');
+			jQuery('#billing_state').replaceWith('<select id="billing_state" name="billing_state" class="pmpro_form_input pmpro_form_input-select"></select>');
 		} else {
-			jQuery('#billing_state').replaceWith('<input type="text" id="billing_state" name="billing_state" />');
+			jQuery('#billing_state').replaceWith('<input type="text" id="billing_state" name="billing_state" class="pmpro_form_input pmpro_form_input-text" />');
 		}
 
 		pmprosd_populate_dropdown("#billing_state", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.bstate);

--- a/js/countries-main.js
+++ b/js/countries-main.js
@@ -14,9 +14,9 @@ jQuery(document).ready(function ($) {
 	//make sure we have a bcountry field to work with
 	if (jQuery('#bcountry').length) {
 
-		//move #bcountry field and label above #bfirstname field and label
+		// Move #bcountry field and label above #bcity field and label.
 		var bcountryDiv = jQuery('label[for="bcountry"]').closest('div');
-		bcountryDiv.insertBefore(jQuery('label[for="bfirstname"]').closest('div'));
+		bcountryDiv.insertBefore(jQuery('label[for="bcity"]').closest('div'));
 
 		// Get the states for a specific country.
 		var states_for_countries = pmprosd_states[pmpro_state_dropdowns.bcountry];
@@ -62,8 +62,8 @@ jQuery(document).ready(function ($) {
 	//pmpro-shipping support
 	if (jQuery('#pmpro_scountry').length) {
 
-		// Move Shipping Country field above state for better UX.
-		jQuery('#pmpro_scountry_div').insertBefore(jQuery('#pmpro_sstate_div').closest('div'));
+		// Move Shipping Country field above city for better UX.
+		jQuery('#pmpro_scountry_div').insertBefore(jQuery('#pmpro_scity_div').closest('div'));
 
 		pmprosd_populate_dropdown("#pmpro_scountry", pmprosd_countries, pmpro_state_labels.country, pmpro_state_dropdowns.scountry);
 

--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -39,7 +39,11 @@ class PMPro_State_Dropdowns {
 
 		// Force the long address functionality to ensure that the country fields are always shown.
 		add_filter( 'pmpro_international_addresses', '__return_true' );
-		add_filter( 'pmpro_longform_address', '__return_true' );
+
+		// Only add this in for Pre 3.1 versions of PMPro.
+		if ( defined( 'PMPRO_VERSION' ) && version_compare( PMPRO_VERSION, '3.1', '<' ) ) {
+			add_filter( 'pmpro_longform_address', '__return_true' );
+		}	
 
 		/**
 		 * Load plugin's textdomain for translations

--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -1,9 +1,9 @@
 <?php
 /*
-Plugin Name: Paid Memberships Pro - State Dropdowns Add On
+Plugin Name: Paid Memberships Pro - State Dropdowns
 Plugin URI: https://www.paidmembershipspro.com/add-ons/state-dropdown/
 Description: Creates an autopopulated field for countries and states/provinces for billing fields.
-Version: 0.4.4
+Version: 0.5
 Author: Paid Memberships Pro
 Author URI: https://www.paidmembershipspro.com
 License: GPL2 or later
@@ -13,6 +13,8 @@ Network: false
 */
 
 defined( 'ABSPATH' ) or exit;
+
+define( 'PMPROSD_VERSION', '0.5' );
 
 require_once dirname( __FILE__ ) . '/includes/states.php';
 
@@ -77,7 +79,7 @@ class PMPro_State_Dropdowns {
 		 * Register our JS scripts
 		 */		
 		global $pmpro_countries;
-		wp_register_script( 'pmpro-countries-main', plugins_url( '/js/countries-main.js', __FILE__ ), array('jquery') );		
+		wp_register_script( 'pmpro-countries-main', plugins_url( '/js/countries-main.js', __FILE__ ), array('jquery'), PMPROSD_VERSION, array( 'in_footer' => true ) );
 		wp_localize_script( 'pmpro-countries-main', 'pmpro_state_labels', array( 'country' => __( 'Select country', 'pmpro-state-dropdowns' ), 'region' => __( 'Select state', 'pmpro-state-dropdowns' ) ) 		);
 		wp_localize_script( 'pmpro-countries-main', 'pmprosd_states', pmprosd_states() );
 		wp_localize_script( 'pmpro-countries-main', 'pmprosd_countries', $pmpro_countries );
@@ -147,7 +149,7 @@ function pmpro_state_dropdowns_plugin_row_meta($links, $file) {
 	{
 		$new_links = array(
 			'<a href="' . esc_url('https://www.paidmembershipspro.com/add-ons/state-dropdown/')  . '" title="' . esc_attr( __( 'View Documentation', 'pmpro-state-dropdowns' ) ) . '">' . __( 'Docs', 'pmpro-state-dropdowns' ) . '</a>',
-			'<a href="' . esc_url('https://paidmembershipspro.com/support/') . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-state-dropdowns' ) ) . '">' . __( 'Support', 'pmpro-state-dropdowns' ) . '</a>',
+			'<a href="' . esc_url('https://www.paidmembershipspro.com/support/') . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-state-dropdowns' ) ) . '">' . __( 'Support', 'pmpro-state-dropdowns' ) . '</a>',
 		);
 		$links = array_merge($links, $new_links);
 	}

--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -1,16 +1,14 @@
 <?php
-/*
-Plugin Name: Paid Memberships Pro - State Dropdowns
-Plugin URI: https://www.paidmembershipspro.com/add-ons/state-dropdown/
-Description: Creates an autopopulated field for countries and states/provinces for billing fields.
-Version: 0.5
-Author: Paid Memberships Pro
-Author URI: https://www.paidmembershipspro.com
-License: GPL2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Text Domain: pmpro-state-dropdowns
-Network: false
-*/
+/**
+ * Plugin Name: Paid Memberships Pro - State Dropdowns
+ * Plugin URI: https://www.paidmembershipspro.com/add-ons/state-dropdown/
+ * Description: Creates an autopopulated field for countries and states/provinces for billing fields.
+ * Version: 0.5
+ * Author: Paid Memberships Pro
+ * Author URI: https://www.paidmembershipspro.com
+ * Text Domain: pmpro-state-dropdowns
+ * Network: false
+ */
 
 defined( 'ABSPATH' ) or exit;
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
-=== Paid Memberships Pro - State Dropdowns Add On ===
+=== Paid Memberships Pro - State Dropdowns ===
 Contributors: strangerstudios
 Tags: paid memberships pro, pmpro, states, counties, provences
-Requires at least: 5.0
-Tested up to: 6.4.2
-Stable tag: 0.4.4
+Requires at least: 5.2
+Tested up to: 6.6
+Stable tag: 0.5
 
 Converts state fields on the checkout, edit profile and order pages to dropdowns autopopulated based on the selected country. 
 
@@ -41,6 +41,11 @@ Existing users that have entered their State/Province before using this add-on m
 Not all countries may be fully supported regarding the State/Province list. If you find a fault with your country's State/Province list, please post it in the GitHub issue tracker here: https://github.com/strangerstudios/pmpro-state-dropdowns/issues
 
 == Changelog ==
+= 0.5 - 2024-07-18 =
+* ENHANCEMENT: Updated the frontend UI for compatibility with PMPro v3.1.
+* ENHANCEMENT: Now moving the Country field before the City field for better UX.
+* BUG FIX: Only using the `pmpro_longform_address` filter on pre-v3.1+ versions of PMPro (now the default behavior).
+
 = 0.4.4 - 2024-01-05 =
  * ENHANCEMENT: Moved Kosovo out of state options for Serbia. (@andrewlimaza)
  * ENHANCEMENT: Added states for Singapore and United Kingdom. (@andrewlimaza, @ipokkel)

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,8 @@ Tags: paid memberships pro, pmpro, states, counties, provences
 Requires at least: 5.2
 Tested up to: 6.6
 Stable tag: 0.5
+License: GPLv3
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 Converts state fields on the checkout, edit profile and order pages to dropdowns autopopulated based on the selected country. 
 


### PR DESCRIPTION
* ENHANCEMENT: Added better support for V3.1 Paid Memberships Pro

* ENHANCEMENT: Added better support for Shipping Add On (Same As) functionality.

* REFACTOR: Refactored code slightly to be easier to work with and understand.

Note that the JS file manually adds the CSS class, this is how it was done in the past and won't be filterable using the pmpro_get_element_class at this point when using this Add On. We should find ways to support this.

Resolves: [#63](https://github.com/strangerstudios/pmpro-state-dropdowns/issues/63)
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?