### PR TITLE
* Add support to business address fields in payments gateway admin side.

### DIFF
--- a/js/countries-main.js
+++ b/js/countries-main.js
@@ -1,11 +1,12 @@
 jQuery(document).ready(function ($) {
 
 	//for compatibility with older PMPro, make sure bcountry fields have ids
-	jQuery("[name='bcountry']").attr('id', 'bcountry');
-	jQuery("[name='scountry']").attr('id', 'scountry');
 
-	jQuery("[name='pmpro_bcountry']").attr('id', 'bcountry');
-	jQuery("[name='pmpro_bstate']").attr('id', 'bstate');
+	$("[name='bcountry']").attr('id', 'bcountry');
+	$("[name='scountry']").attr('id', 'scountry');
+
+	$("[name='pmpro_bcountry']").attr('id', 'bcountry');
+	$("[name='pmpro_bstate']").attr('id', 'bstate');
 
 	// Populate the dropdown on page load.
 	var selected_states = pmprosd_states[pmpro_state_dropdowns.bcountry];
@@ -132,6 +133,28 @@ jQuery(document).ready(function ($) {
 		pmprosd_populate_dropdown("#billing_state", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.bstate);
 
 	}
+
+	//PMPro payment settings page support
+	if ( $('#business_country').length ) {
+		//Replace the country text input with a dropdown
+		$( '#business_country' ).replaceWith('<select id="business_country" name="business_country" class="regular-text"></select>');
+		pmprosd_populate_dropdown( '#business_country', pmprosd_countries, pmpro_state_labels.country, pmpro_state_dropdowns.bcountry );
+		//Replace the state text input with a dropdown
+		$('#business_state').replaceWith( '<select id="business_state" name="business_state" class="regular-text"></select>' );
+		pmprosd_populate_dropdown( '#business_state', selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.bstate );
+
+		$('body').on( 'change', '#business_country', function () {
+			const selected_country = $(this).val();
+			const selected_states = pmprosd_states[selected_country];
+			if (typeof selected_states !== 'undefined' && $(selected_states).length > 0) {
+				$('#business_state').replaceWith( '<select id="business_state" name="business_state" class="regular-text"></select>' );
+			} else {
+				$('#business_state').replaceWith( '<input type="text" id="business_state" name="business_state" class="regular-text" />' );
+			}
+			pmprosd_populate_dropdown( '#business_state', selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.bstate );
+		});
+	}
+
 
 	jQuery('body').on('change', "[name='billing_country']", function () {
 		var selected_country = jQuery(this).val();

--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -65,7 +65,8 @@ class PMPro_State_Dropdowns {
 
 		//we only want to enqueue this on certain pages
 		 $script_name = basename( $_SERVER['SCRIPT_NAME'] );
-		if( is_admin() &&  $script_name !== 'user-edit.php' && 
+		if( is_admin() && ( isset( $_REQUEST['page'] ) && $_REQUEST['page'] !== 'pmpro-paymentsettings' ) &&
+			is_admin() &&  $script_name !== 'user-edit.php' &&
 						   $script_name !== 'profile.php' && 
 						  ( empty( $_REQUEST['page'] ) || $_REQUEST['page'] != 'pmpro-addmember' && $_REQUEST['page'] != 'pmpro-orders'  ) ){
 			return;


### PR DESCRIPTION
### All Submissions:


<img width="922" alt="image" src="https://github.com/user-attachments/assets/ca6ba2e9-f5f3-4332-97ec-b05eca38208c">
<img width="738" alt="image" src="https://github.com/user-attachments/assets/1e4f4ca4-136e-4953-89c1-1941549740c5">


* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

 Add further scenario to support payments settings page in the admin side

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.