### PR TITLE
Retain submitted shipping state and country field values when checkout fails

### DIFF
--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -112,16 +112,16 @@ class PMPro_State_Dropdowns {
 				$user_saved_countries['bstate'] = get_user_meta( $user_id, 'pmpro_bstate', true );
 			}
 
-			if( isset( $_REQUEST['scountry'] ) ){
-				$user_saved_countries['scountry'] = sanitize_text_field( $_REQUEST['scountry'] );
+			if( isset( $_REQUEST['pmpro_scountry'] ) ){
+				$user_saved_countries['scountry'] = sanitize_text_field( $_REQUEST['pmpro_scountry'] );
 			}elseif ( empty( get_user_meta( $user_id, 'pmpro_scountry', true ) ) ) {
 				$user_saved_countries['scountry'] = $pmpro_default_country;
 			}else{
 				$user_saved_countries['scountry'] = get_user_meta( $user_id, 'pmpro_scountry', true );
 			}
 
-			if( isset( $_REQUEST['sstate'] ) ){
-				$user_saved_countries['sstate'] = sanitize_text_field( $_REQUEST['sstate'] );
+			if( isset( $_REQUEST['pmpro_sstate'] ) ){
+				$user_saved_countries['sstate'] = sanitize_text_field( $_REQUEST['pmpro_sstate'] );
 			}else{
 				$user_saved_countries['sstate'] = get_user_meta( $user_id, 'pmpro_sstate', true );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
User submitted Mailing Address _state_ and _country_ field values were not being retained if checkout checks failed.

Updates the `sstate` and `scountry` $_REQUEST keys to `pmpro_scountry` and `pmpro_sstate`, matching the keys used by the Mailing Address Add On.


Closes Issue: #67.

### How to test the changes in this Pull Request:

1. Activate Mailing Address Add On.
2. While logged out, fill in mailing address and submit checkout form using an email that exists on site.
3. Observe that your submitted State and Country address details were not retained.
4. Apply PR.
5. While logged out, fill in mailing address and submit checkout form using an email that exists on site.
6. Observe that your State and Country selections were retained.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Retain submitted shipping state and country field values when checkout fails