### PR TITLE
Adding compatibility with PMPro v3.6

### DIFF
--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -93,10 +93,10 @@ class PMPro_State_Dropdowns {
 
 		//check to see if user is  on the admin page.
 		if ( is_admin() && isset($_REQUEST['page']) && $_REQUEST['page'] == 'pmpro-orders' && !empty($_GET['id']) ) {
-			$morder = new MemberOrder($_GET['id']);
+			$morder = new MemberOrder( absint( $_GET['id'] ) );
 		} elseif ( is_admin() && isset($_REQUEST['page']) && $_REQUEST['page'] == 'pmpro-orders' && !empty($_GET['order']) ) {
 			// Pre-3.6 compatibility.
-			$morder = new MemberOrder($_GET['order']);
+			$morder = new MemberOrder( absint( $_GET['order'] ) );
 		}
 		
 		//if $morder is not empty (i.e. on the orders page try to get details from REQUEST or USER META )

--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -92,7 +92,10 @@ class PMPro_State_Dropdowns {
 		$user_saved_countries = array();
 
 		//check to see if user is  on the admin page.
-		if ( is_admin() && isset($_REQUEST['page']) && $_REQUEST['page'] == 'pmpro-orders' && !empty($_GET['order']) ) {
+		if ( is_admin() && isset($_REQUEST['page']) && $_REQUEST['page'] == 'pmpro-orders' && !empty($_GET['id']) ) {
+			$morder = new MemberOrder($_GET['id']);
+		} elseif ( is_admin() && isset($_REQUEST['page']) && $_REQUEST['page'] == 'pmpro-orders' && !empty($_GET['order']) ) {
+			// Pre-3.6 compatibility.
 			$morder = new MemberOrder($_GET['order']);
 		}
 		


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-state-dropdowns/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In PMPro v3.6, the URL parameter used to pass an order ID to the "edit order" page changed from `order` to `id`.  Without this fix, the order being edited would not be located and the plugin would fall back to user meta or the default country.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.