### PR TITLE
Update "State" behavior if the country has no states.

### DIFF
--- a/js/countries-main.js
+++ b/js/countries-main.js
@@ -7,56 +7,60 @@ jQuery(document).ready(function ($) {
 	jQuery("[name='pmpro_bcountry']").attr('id', 'bcountry');
 	jQuery("[name='pmpro_bstate']").attr('id', 'bstate');
 
-	// Populate the dropdown on page load.
-	var selected_states = pmprosd_states[pmpro_state_dropdowns.bcountry];
-	pmprosd_populate_dropdown("#bstate", selected_states, pmpro_state_labels.region, '');
+	// Whether a states object actually has any states/provinces in it.
+	function pmprosd_has_states(states) {
+		return typeof states !== 'undefined' && states !== null && Object.keys(states).length > 0;
+	}
+
+	/**
+	 * Build the state field for a country: a populated dropdown if the country has states,
+	 * or hide the field entirely (and clear its value) if it doesn't have any states so that
+	 * it isn't shown or required at checkout.
+	 *
+	 * @param {string} id       The id (and name) of the state field, e.g. "bstate" or "pmpro_sstate".
+	 * @param {string} wrapper  A selector for the field's wrapping element to show/hide.
+	 * @param {Object} states   The states for the currently selected country, keyed by abbreviation.
+	 * @param {string} selected The value that should be selected/prefilled, if any.
+	 */
+	function pmprosd_update_state_field(id, wrapper, states, selected) {
+		var $field = jQuery('#' + id);
+		var $wrapper = jQuery(wrapper);
+		var has_error = $field.hasClass('pmpro_form_input-error');
+
+		if (!pmprosd_has_states(states)) {
+			// The selected country doesn't have any states/provinces defined.
+			// Clear the value so it isn't submitted, and hide the field so it isn't shown or required.
+			$field.val('');
+			$wrapper.hide();
+			return;
+		}
+
+		// The selected country has states/provinces. Make sure the field is visible and rebuild it as a dropdown.
+		$wrapper.show();
+
+		var error_class = has_error ? 'pmpro_form_input-error ' : '';
+		$field.replaceWith('<select id="' + id + '" name="' + id + '" class="' + error_class + 'pmpro_form_input pmpro_form_input-select"></select>');
+
+		pmprosd_populate_dropdown('#' + id, states, pmpro_state_labels.region, selected);
+	}
+
+	//make sure we have a bstate field to work with
+	if (jQuery('#bstate').length) {
+		var selected_states = pmprosd_states[pmpro_state_dropdowns.bcountry];
+		pmprosd_update_state_field('bstate', '.pmpro_form_field-bstate', selected_states, pmpro_state_dropdowns.bstate);
+	}
 
 	//make sure we have a bcountry field to work with
 	if (jQuery('#bcountry').length) {
-
 		// Move #bcountry field and label above #bcity field and label.
 		var bcountryDiv = jQuery('label[for="bcountry"]').closest('div');
 		bcountryDiv.insertBefore(jQuery('label[for="bcity"]').closest('div'));
-
-		// Get the states for a specific country.
-		var states_for_countries = pmprosd_states[pmpro_state_dropdowns.bcountry];
-		if (typeof states_for_countries !== 'undefined' && jQuery(states_for_countries).length > 0) {
-			if (jQuery('#bstate').hasClass('pmpro_form_input-error')) {
-				jQuery("#bstate").replaceWith('<select id="bstate" name="bstate" class="pmpro_form_input-error pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate
-			} else {
-				jQuery("#bstate").replaceWith('<select id="bstate" name="bstate" class="pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate
-			}
-
-			pmprosd_populate_dropdown("#bstate", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.bstate);
-		} else {
-			var selected_state = (typeof pmpro_state_dropdowns.bstate !== 'undefined') ? pmpro_state_dropdowns.bstate : "";
-			if (jQuery('#bstate').hasClass('pmpro_form_input-error')) {
-				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" class="pmpro_form_input-error pmpro_form_input pmpro_form_input-text" value="' + selected_state + '"/>');
-			} else {
-				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '"/>');
-			}
-		}
-
 	}
 
 	jQuery('body').on('change', "#bcountry", function () {
 		var selected_country = jQuery(this).val();
 		var selected_states = pmprosd_states[selected_country];
-		if (typeof selected_states !== 'undefined' && jQuery(selected_states).length > 0) {
-			if (jQuery("#bstate").hasClass('pmpro_form_input-error')) {
-				jQuery("#bstate").replaceWith('<select id="bstate" name="bstate" class="pmpro_form_input-error pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate
-			} else {
-				jQuery("#bstate").replaceWith('<select id="bstate" name="bstate" class="pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate
-			}
-			pmprosd_populate_dropdown("#bstate", selected_states, pmpro_state_labels.region, '');
-		} else {
-			var selected_state = (typeof pmpro_state_dropdowns.bstate !== 'undefined') ? pmpro_state_dropdowns.bstate : "";
-			if (jQuery('#bstate').hasClass('pmpro_form_input-error')) {
-				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" class="pmpro_form_input-error pmpro_form_input pmpro_form_input-text" value="' + selected_state + '"/>');
-			} else {
-				jQuery("#bstate").replaceWith('<input type="text" id="bstate" name="bstate" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '"/>');
-			}
-		}
+		pmprosd_update_state_field('bstate', '.pmpro_form_field-bstate', selected_states, '');
 	});
 
 	//pmpro-shipping support
@@ -68,49 +72,21 @@ jQuery(document).ready(function ($) {
 		pmprosd_populate_dropdown("#pmpro_scountry", pmprosd_countries, pmpro_state_labels.country, pmpro_state_dropdowns.scountry);
 
 		var selected_states = pmprosd_states[pmpro_state_dropdowns.scountry];
-		if (typeof selected_states !== 'undefined' && jQuery(selected_states).length > 0) {
-			if (jQuery("#pmpro_sstate").hasClass('pmpro_form_input-error')) {
-				jQuery('#pmpro_sstate').replaceWith('<select id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input-error pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate   
-			} else {
-				jQuery('#pmpro_sstate').replaceWith('<select id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate   
-			}
-			pmprosd_populate_dropdown("#pmpro_sstate", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.sstate);
-		} else {
-			var selected_state = (typeof pmpro_state_dropdowns.sstate !== 'undefined') ? pmpro_state_dropdowns.sstate : "";
-			if (jQuery("#pmpro_sstate").hasClass('pmpro_form_input-error')) {
-				jQuery("#pmpro_sstate").replaceWith('<input type="text" id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input-error pmpro_form_input pmpro_form_input-text" value="' + selected_state + '" />');
-			} else {
-				jQuery("#pmpro_sstate").replaceWith('<input type="text" id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '" />');
-			}
-		}
-
+		pmprosd_update_state_field('pmpro_sstate', '#pmpro_sstate_div', selected_states, pmpro_state_dropdowns.sstate);
 	}
 
 	jQuery('body').on('change', "#pmpro_scountry", function () {
 		var selected_country = jQuery(this).val();
 		var selected_states = pmprosd_states[selected_country];
-		if (typeof selected_states !== 'undefined' && jQuery(selected_states).length > 0) {
-			if (jQuery("#pmpro_sstate").hasClass('pmpro_form_input-error')) {
-				jQuery("#pmpro_sstate").replaceWith('<select id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input-error pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate   
-			} else {
-				jQuery("#pmpro_sstate").replaceWith('<select id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input pmpro_form_input-select"></select>');  //convert to dropdown so states can auto-populate   
-			}
-			pmprosd_populate_dropdown("#pmpro_sstate", selected_states, pmpro_state_labels.region, pmpro_state_dropdowns.sstate);
-		} else {
-			var selected_state = (typeof pmpro_state_dropdowns.sstate !== 'undefined') ? pmpro_state_dropdowns.sstate : "";
-			if (jQuery("#pmpro_sstate").hasClass('pmpro_form_input-error')) {
-				jQuery("#pmpro_sstate").replaceWith('<input type="text" id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input-error" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '" />');
-			} else {
-				jQuery("#pmpro_sstate").replaceWith('<input type="text" id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '" />');
-			}
-		}
+		pmprosd_update_state_field('pmpro_sstate', '#pmpro_sstate_div', selected_states, '');
 	});
 
-	// Add support for Same as billing and set the state to a text field.
+	// Add support for Same as billing: keep the shipping state field in sync with the billing state field/country.
 	jQuery('#pmproship_same_billing_address').on('change', function () {
 		if (jQuery(this).is(':checked')) {
 			var selected_state = jQuery('#bstate').val();
-			jQuery("#pmpro_sstate").replaceWith('<input type="text" id="pmpro_sstate" name="pmpro_sstate" class="pmpro_form_input pmpro_form_input-text" value="' + selected_state + '" />');
+			var billing_states = pmprosd_states[jQuery('#bcountry').val()];
+			pmprosd_update_state_field('pmpro_sstate', '#pmpro_sstate_div', billing_states, selected_state);
 		}
 	});
 

--- a/pmpro-state-dropdowns.php
+++ b/pmpro-state-dropdowns.php
@@ -30,6 +30,80 @@ class PMPro_State_Dropdowns {
 
 	private function __construct() {
 		add_action( 'init', array( $this, 'init' ) );
+
+		// Stop requiring the billing state field when the selected billing country has no states defined.
+		add_filter( 'pmpro_required_billing_fields', array( $this, 'filter_required_billing_fields' ) );
+
+		// Stop requiring the shipping state field (PMPro Shipping Add On) when the selected shipping country
+		// has no states defined. Runs after PMPro Shipping registers its fields on 'init' (priority 10).
+		add_action( 'init', array( $this, 'update_shipping_state_requirement' ), 20 );
+	}
+
+	/**
+	 * Get the country to use when checking whether a state field should be required.
+	 *
+	 * Uses the submitted value if there is one, otherwise falls back to the user's saved
+	 * country or the site's default country, matching the way the country is defaulted
+	 * elsewhere in this plugin.
+	 *
+	 * @param string $request_key The $_REQUEST key that holds the submitted country (e.g. 'bcountry').
+	 * @param string $meta_key    The user meta key that stores the saved country (e.g. 'pmpro_bcountry').
+	 * @return string
+	 */
+	private function get_current_country( $request_key, $meta_key ) {
+		global $current_user, $pmpro_default_country;
+
+		if ( isset( $_REQUEST[ $request_key ] ) ) {
+			return sanitize_text_field( wp_unslash( $_REQUEST[ $request_key ] ) );
+		}
+
+		$saved_country = ! empty( $current_user->ID ) ? get_user_meta( $current_user->ID, $meta_key, true ) : '';
+
+		return ! empty( $saved_country ) ? $saved_country : $pmpro_default_country;
+	}
+
+	/**
+	 * Filter the required billing fields at checkout to remove the billing state field
+	 * when the selected billing country doesn't have any states/provinces defined.
+	 *
+	 * @param array $fields The billing fields required at checkout, keyed by field name.
+	 * @return array
+	 */
+	function filter_required_billing_fields( $fields ) {
+		if ( ! isset( $fields['bstate'] ) ) {
+			return $fields;
+		}
+
+		$bcountry = $this->get_current_country( 'bcountry', 'pmpro_bcountry' );
+		$states   = pmprosd_states();
+
+		if ( isset( $states[ $bcountry ] ) && empty( $states[ $bcountry ] ) ) {
+			unset( $fields['bstate'] );
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Stop requiring the shipping state field (added by the PMPro Shipping Add On) when the
+	 * selected shipping country doesn't have any states/provinces defined.
+	 */
+	function update_shipping_state_requirement() {
+		if ( ! class_exists( 'PMPro_Field_Group' ) ) {
+			return;
+		}
+
+		$sstate_field = PMPro_Field_Group::get_field( 'pmpro_sstate' );
+		if ( empty( $sstate_field ) ) {
+			return;
+		}
+
+		$scountry = $this->get_current_country( 'pmpro_scountry', 'pmpro_scountry' );
+		$states   = pmprosd_states();
+
+		if ( isset( $states[ $scountry ] ) && empty( $states[ $scountry ] ) ) {
+			$sstate_field->required = false;
+		}
 	}
 
 	function init(){
@@ -43,7 +117,7 @@ class PMPro_State_Dropdowns {
 		// Only add this in for Pre 3.1 versions of PMPro.
 		if ( defined( 'PMPRO_VERSION' ) && version_compare( PMPRO_VERSION, '3.1', '<' ) ) {
 			add_filter( 'pmpro_longform_address', '__return_true' );
-		}	
+		}
 
 		/**
 		 * Load plugin's textdomain for translations


### PR DESCRIPTION
When using this add on, if a country that has no "state" requirements is selected, the state fields will be hidden and not required any longer.

All Submissions:

- [x] Have you followed the Contributing guideline?
- [x] Does your code follow WordPress' coding standards?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

Changes proposed in this Pull Request:

When using this Add On, if a country with no "state" requirements is selected, the state fields will be hidden and no longer required.

Previously, when a country with no states/provinces defined (e.g. France, Belgium, Denmark, Finland, and ~35 others in states.php) was selected, the state field would fall back to a free-text input that was still enforced as a required field. Since these countries don't have a defined list of states/provinces, this field served no purpose and could block checkout.

This PR:
- Hides the billing state field (and clears its value) instead of converting it to a text input when the selected billing country has no states defined, on the checkout page and the "Your Billing" profile page.
- Removes bstate from the required billing fields check (via the pmpro_required_billing_fields filter) under the same condition, so checkout is no longer blocked.
- Applies the same hide + not-required behavior to the shipping state field added by the PMPro Shipping Add On, wherever it's shown (checkout and profile), including when "Same as billing" is used.

How to test the changes in this Pull Request:

1. Activate Paid Memberships Pro and the PMPro State Dropdowns Add On (optionally also the PMPro Shipping Add On).
2. Go to the checkout page for a paid level and select a country with no states defined, such as France, Belgium, Denmark, or Finland. Confirm the State field disappears.
3. Submit the checkout form without filling in a state. Confirm checkout is not blocked for a missing state.
4. Switch the country back to one with states, such as the United States or Canada. Confirm the State field reappears as a populated dropdown.
5. Repeat steps 2-4 on the "Your Billing"/profile edit page.
6. If the PMPro Shipping Add On is active, repeat steps 2-4 for the shipping country/state fields, and confirm the "Same as billing" checkbox still works correctly.

Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?

Changelog entry

▎ The state/province field is now hidden and no longer required at checkout (and on the billing/profile page) when the selected country has no states/provinces defined. This also applies when the PMPro Shipping Add-On is active.